### PR TITLE
ci: Add dummy workflow to build images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,16 @@
+# This is a placeholder workflow and will be replaced once the appropriate
+# functionality passes code review.
+#
+# Dispatching workflow calls to a GHA workflow on a branch requires that a
+# workflow file with the correct name exists in the default branch, even
+# if that workflow bears no resemblance to the target workflow
+
+name: Build FPM Images
+on:
+  workflow_dispatch:
+jobs:
+  dummy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Greeting
+        run: echo "This is a dummy build to placate GitHub."


### PR DESCRIPTION
Add a dummy workflow so the actual workflow can be developed. This is
standard procedure as you cannot dispatch to a workflow that does not
exist on the main branch, even if a dev branch has the workflow.

A subsequent PR will flesh out the workflow to actually build the
container images and push to ECR.