### PR TITLE
Fixed image building problem on centos 8

### DIFF
--- a/centos/8/Dockerfile
+++ b/centos/8/Dockerfile
@@ -5,7 +5,8 @@ RUN set -x \
         -e 's/^mirrorlist/#mirrorlist/g' \
         -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' \
         /etc/yum.repos.d/CentOS-* \
-    && yum install -y ruby-devel rubygems gcc make rpmdevtools rpm-sign \
+    && yum module -y enable ruby:3.0 \
+    && yum install -y ruby rubygems gcc make rpmdevtools rpm-sign \
     && gem install fpm -v 1.15.1 \
     && yum clean all \
     && mkdir /src


### PR DESCRIPTION
A dependency bumped the minimum required Ruby version and now the centos 8 image won't build. This PR fixes the issue by installing the new required version (>= 3.0), which is not enabled by default on centos 8.

Passing build here: https://github.com/gravitational/docker-fpm/actions/runs/8649636857/job/23716341973