### PR TITLE
Publish to GHCR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,8 +27,9 @@ jobs:
             label: debian12
     runs-on: ubuntu-latest
     permissions:
-      id-token: write  # required for aws-actions/configure-aws-credentials
+      id-token: write # required for aws-actions/configure-aws-credentials
       contents: read
+      packages: write # Required to push container images
     steps:
       - name: version
         env:
@@ -59,6 +60,12 @@ jobs:
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build FPM Image
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
@@ -67,4 +74,4 @@ jobs:
           file: ${{ matrix.directory }}/Dockerfile
           platforms: linux/amd64,linux/arm64
           tags: |
-            public.ecr.aws/gravitational/fpm:${{ matrix.label }}-${{ env.V }}
+            public.ecr.aws/gravitational/fpm:${{ matrix.label }}-${{ env.V }},ghcr.io/gravitational/fpm:${{ matrix.label }}-${{ env.V }}


### PR DESCRIPTION
Added support for publishing to GHCR. This should (eventually) allow us to build some Teleport binaries without logging into ECR at all.

Passing workflow run here: https://github.com/gravitational/docker-fpm/actions/runs/8649755153
Built image available here: https://github.com/gravitational/docker-fpm/pkgs/container/fpm